### PR TITLE
feat: Introduce Auth controller extender

### DIFF
--- a/src/Controllers/AbstractOAuthController.php
+++ b/src/Controllers/AbstractOAuthController.php
@@ -115,22 +115,23 @@ abstract class AbstractOAuthController implements RequestHandlerInterface
     /**
      * Fast Track OAuth Flow.
      *
-     * The `fastTrack` method provides a mechanism to expedite the OAuth authentication process 
-     * under certain conditions. Specifically, when a session indicates a `fastTrack` state and 
-     * contains the necessary `oauth_data` (i.e., both `token` and `resourceOwner`), this method 
+     * The `fastTrack` method provides a mechanism to expedite the OAuth authentication process
+     * under certain conditions. Specifically, when a session indicates a `fastTrack` state and
+     * contains the necessary `oauth_data` (i.e., both `token` and `resourceOwner`), this method
      * can be utilized to bypass the standard flow and directly handle the OAuth response.
      *
-     * This can be particularly useful in scenarios where the initial OAuth parameters, provided 
-     * by the authentication provider, have expired due to additional steps in the flow (e.g., 
-     * two-factor authentication). Instead of going through the entire OAuth flow again, the 
+     * This can be particularly useful in scenarios where the initial OAuth parameters, provided
+     * by the authentication provider, have expired due to additional steps in the flow (e.g.,
+     * two-factor authentication). Instead of going through the entire OAuth flow again, the
      * `fastTrack` mechanism uses the saved session data to resume and complete the process.
      *
-     * It's essential to ensure the integrity and validity of the saved session data before 
-     * using this method. The method will return the response of the OAuth flow if the conditions 
+     * It's essential to ensure the integrity and validity of the saved session data before
+     * using this method. The method will return the response of the OAuth flow if the conditions
      * are met, or null otherwise.
      *
-     * @param Store $session The current session instance containing potential OAuth data.
+     * @param Store                  $session The current session instance containing potential OAuth data.
      * @param ServerRequestInterface $request The current server request.
+     *
      * @return ResponseInterface|null The response of the OAuth flow if fast-tracked, or null.
      */
     protected function fastTrack(Store $session, ServerRequestInterface $request): ?ResponseInterface
@@ -191,7 +192,7 @@ abstract class AbstractOAuthController implements RequestHandlerInterface
         $authUrl = $provider->getAuthorizationUrl($this->getAuthorizationUrlOptions());
         $session->put(self::SESSION_OAUTH2STATE, $provider->getState());
 
-        return new RedirectResponse($authUrl . '&display=' . $this->getDisplayType());
+        return new RedirectResponse($authUrl.'&display='.$this->getDisplayType());
     }
 
     /**

--- a/src/Extend/OAuthController.php
+++ b/src/Extend/OAuthController.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/extend.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Extend\Extend;
 
 use Flarum\Extend\ExtenderInterface;
@@ -22,7 +31,7 @@ class OAuthController implements ExtenderInterface
      * - $token: An instance of \League\OAuth2\Client\Token\AccessTokenInterface, representing the access token.
      * - $resourceOwner: An instance of \League\OAuth2\Client\Provider\ResourceOwnerInterface, representing the authenticated user's resource.
      * - $identification: A string identifying `fof/oauth` provider, e.g. `github.
-     * 
+     *
      * It should return either `void` if no further action is required from the callback, or `Psr\Http\Message\ResponseInterface`.
      *
      * @return $this

--- a/src/Extend/OAuthController.php
+++ b/src/Extend/OAuthController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace FoF\Extend\Extend;
+
+use Flarum\Extend\ExtenderInterface;
+use Flarum\Extension\Extension;
+use Flarum\Foundation\ContainerUtil;
+use FoF\Extend\Controllers\AbstractOAuthController;
+use Illuminate\Contracts\Container\Container;
+
+class OAuthController implements ExtenderInterface
+{
+    protected $afterOAuthSuccessCallbacks = [];
+
+    /**
+     * Register a callback to be executed after a successful OAuth login, but before the user is logged in to Flarum.
+     *
+     * @param callable|string $callback
+     *
+     * The callback can be a closure or an invokable class and should accept:
+     * - $request: An instance of \Psr\Http\Message\ServerRequestInterface.
+     * - $token: An instance of \League\OAuth2\Client\Token\AccessTokenInterface, representing the access token.
+     * - $resourceOwner: An instance of \League\OAuth2\Client\Provider\ResourceOwnerInterface, representing the authenticated user's resource.
+     * - $identification: A string identifying `fof/oauth` provider, e.g. `github.
+     * 
+     * It should return either `void` if no further action is required from the callback, or `Psr\Http\Message\ResponseInterface`.
+     *
+     * @return $this
+     */
+    public function afterOAuthSuccess($callback)
+    {
+        $this->afterOAuthSuccessCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        foreach ($this->afterOAuthSuccessCallbacks as $index => $callback) {
+            $this->afterOAuthSuccessCallbacks[$index] = ContainerUtil::wrapCallback($callback, $container);
+        }
+
+        AbstractOAuthController::setAfterOAuthSuccessCallbacks($this->afterOAuthSuccessCallbacks);
+    }
+}


### PR DESCRIPTION
- Implemented the ability to register custom callbacks to be executed after the OAuth success flow. This provides developers with more flexibility and control over post-authentication actions.

Usage example in `extend.php`:
```php
(new \FoF\Extend\Extend\OAuthController())
    ->afterOAuthSuccess(MyCallback::class),
```

This must be an invokable class or closure. It may return `ResponseInterface` or `void`/`null`

- Introduced a `fastTrack` method to expedite the OAuth authentication process under specific conditions. Useful when initial OAuth parameters have expired due to additional intermediary steps (e.g., 2FA). Instead of re-initiating the entire OAuth flow, the fastTrack method leverages saved session data to resume and complete the process.