### PR TITLE
fix: use cache storage instead of session

### DIFF
--- a/src/Controllers/AbstractOAuthController.php
+++ b/src/Controllers/AbstractOAuthController.php
@@ -417,23 +417,64 @@ abstract class AbstractOAuthController implements RequestHandlerInterface
      */
     abstract protected function setSuggestions(Registration $registration, $user, string $token);
 
+    /**
+     * Store data in cache.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param Store $session
+     * @return boolean
+     */
     protected function put(string $key, $value, Store $session): bool
     {
-        return $this->cache->put($key . '_' . $session->getId(), $value, self::OAUTH_DATA_CACHE_LIFETIME);
+        return $this->cache->put($this->buildKey($key, $session), $value, self::OAUTH_DATA_CACHE_LIFETIME);
     }
 
-    protected function get($key, Store $session)
+    /**
+     * Get data from cache.
+     *
+     * @param string $key
+     * @param Store $session
+     * @return mixed|null
+     */
+    protected function get(string $key, Store $session)
     {
-        return $this->cache->get($key . '_' . $session->getId());
+        return $this->cache->get($this->buildKey($key, $session));
     }
 
-    protected function forget($key, Store $session): bool
+    /**
+     * Remove data from the cache.
+     *
+     * @param string $key
+     * @param Store $session
+     * @return boolean
+     */
+    protected function forget(string $key, Store $session): bool
     {
-        return $this->cache->forget($key . '_' . $session->getId());
+        return $this->cache->forget($this->buildKey($key, $session));
     }
 
-    protected function has($key, Store $session): bool
+    /**
+     * Check if a key exists in the cache.
+     *
+     * @param string $key
+     * @param Store $session
+     * @return boolean
+     */
+    protected function has(string $key, Store $session): bool
     {
-        return !!$this->cache->get($key . '_' . $session->getId());
+        return !!$this->cache->get($this->buildKey($key, $session));
+    }
+
+    /**
+     * Build the cache store key.
+     *
+     * @param string $key
+     * @param Store $session
+     * @return string
+     */
+    protected function buildKey(string $key, Store $session): string
+    {
+        return "{$key}_{$session->getId()}";
     }
 }

--- a/src/Controllers/AbstractOAuthController.php
+++ b/src/Controllers/AbstractOAuthController.php
@@ -55,7 +55,7 @@ abstract class AbstractOAuthController implements RequestHandlerInterface
     /**
      * How long to cache OAuth data for in seconds.
      */
-    static $OAUTH_DATA_CACHE_LIFETIME = 60;
+    static $OAUTH_DATA_CACHE_LIFETIME = 60 * 5; // 5 minutes
 
     /**
      * @var ResponseFactory

--- a/src/Controllers/AbstractOAuthController.php
+++ b/src/Controllers/AbstractOAuthController.php
@@ -322,7 +322,6 @@ abstract class AbstractOAuthController implements RequestHandlerInterface
     {
         $actor = RequestUtil::getActor($request);
 
-        $linkTo = $this->get(self::SESSION_LINKTO, $session);
         $sessionLinkToExists = $this->has(self::SESSION_LINKTO, $session);
 
         // Don't register a new user, just link to the existing account, else continue with registration.
@@ -331,7 +330,7 @@ abstract class AbstractOAuthController implements RequestHandlerInterface
             // forget the linkTo key
             $this->forget(self::SESSION_LINKTO, $session);
 
-            $sessionLink = (int) $linkTo;
+            $sessionLink = (int) $this->get(self::SESSION_LINKTO, $session);
 
             if ($actor->id !== $sessionLink || $sessionLink === 0) {
                 throw new ValidationException(['linkAccount' => 'User data mismatch']);

--- a/src/Controllers/AbstractOAuthController.php
+++ b/src/Controllers/AbstractOAuthController.php
@@ -53,9 +53,9 @@ abstract class AbstractOAuthController implements RequestHandlerInterface
     const SESSION_LINKTO = 'linkTo';
 
     /**
-     * 
+     * How long to cache OAuth data for in seconds.
      */
-    const OAUTH_DATA_CACHE_LIFETIME = 60;
+    static $OAUTH_DATA_CACHE_LIFETIME = 60;
 
     /**
      * @var ResponseFactory
@@ -173,7 +173,7 @@ abstract class AbstractOAuthController implements RequestHandlerInterface
         /** @var Store $session */
         $session = $request->getAttribute('session');
 
-        $this->put(self::SESSION_OAUTH2PROVIDER, $this->getProviderName(), $session);
+        $this->putForever(self::SESSION_OAUTH2PROVIDER, $this->getProviderName(), $session);
 
         if ($requestLinkTo = Arr::get($request->getQueryParams(), 'linkTo')) {
             $this->put(self::SESSION_LINKTO, $requestLinkTo, $session);
@@ -418,7 +418,7 @@ abstract class AbstractOAuthController implements RequestHandlerInterface
     abstract protected function setSuggestions(Registration $registration, $user, string $token);
 
     /**
-     * Store data in cache.
+     * Store data in cache for the default amount of time.
      *
      * @param string $key
      * @param mixed $value
@@ -427,7 +427,20 @@ abstract class AbstractOAuthController implements RequestHandlerInterface
      */
     protected function put(string $key, $value, Store $session): bool
     {
-        return $this->cache->put($this->buildKey($key, $session), $value, self::OAUTH_DATA_CACHE_LIFETIME);
+        return $this->cache->put($this->buildKey($key, $session), $value, self::$OAUTH_DATA_CACHE_LIFETIME);
+    }
+
+    /**
+     * Store data in cache indefinitely.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param Store $session
+     * @return boolean
+     */
+    protected function putForever(string $key, $value, Store $session): bool
+    {
+        return $this->cache->forever($this->buildKey($key, $session), $value);
     }
 
     /**


### PR DESCRIPTION
Storing the oauth data in the `session` is usually fine, but under race conditions where a longer running request is started before an oauth `link` request, this session data can be lost as the session will be overwritten.

To resolve this, we now store the temporary data in the `cache` instead, with a default ttl of 5 minutes.
